### PR TITLE
Adding Possibility To Change TitleBar's Foreground Color

### DIFF
--- a/FluentWPF/AcrylicWindow.cs
+++ b/FluentWPF/AcrylicWindow.cs
@@ -94,6 +94,7 @@ namespace SourceChord.FluentWPF
             NoiseOpacityProperty = AcrylicElement.NoiseOpacityProperty.AddOwner(typeof(AcrylicWindow), new FrameworkPropertyMetadata(0.03, FrameworkPropertyMetadataOptions.Inherits));
             FallbackColorProperty = AcrylicElement.FallbackColorProperty.AddOwner(typeof(AcrylicWindow), new FrameworkPropertyMetadata(Colors.LightGray, FrameworkPropertyMetadataOptions.Inherits));
             ShowTitleBarProperty = AcrylicElement.ShowTitleBarProperty.AddOwner(typeof(AcrylicWindow), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.Inherits));
+            TitleBarForegroundProperty = AcrylicElement.TitleBarForegroundProperty.AddOwner(typeof(AcrylicWindow), new FrameworkPropertyMetadata(Colors.Black, FrameworkPropertyMetadataOptions.Inherits));
             ExtendViewIntoTitleBarProperty = AcrylicElement.ExtendViewIntoTitleBarProperty.AddOwner(typeof(AcrylicWindow), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
         }
 
@@ -254,6 +255,25 @@ namespace SourceChord.FluentWPF
         }
 
 
+        public Color TitleBarForeground
+        {
+            get { return (Color)GetValue(TitleBarForegroundProperty); }
+            set { SetValue(TitleBarForegroundProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for TitleBarColor.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty TitleBarForegroundProperty;
+        public static Color GetTitleBarForeground(DependencyObject obj)
+        {
+            return (Color)obj.GetValue(AcrylicElement.TitleBarForegroundProperty);
+        }
+
+        public static void SetTitleBarForeground(DependencyObject obj, Color value)
+        {
+            obj.SetValue(AcrylicElement.TitleBarForegroundProperty, value);
+        }
+
+
         public bool ExtendViewIntoTitleBar
         {
             get { return (bool)GetValue(ExtendViewIntoTitleBarProperty); }
@@ -399,6 +419,24 @@ namespace SourceChord.FluentWPF
         // Using a DependencyProperty as the backing store for ShowTitleBar.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty ShowTitleBarProperty =
             DependencyProperty.RegisterAttached("ShowTitleBar", typeof(bool), typeof(AcrylicElement), new PropertyMetadata(true));
+
+
+
+
+
+        public static Color GetTitleBarForeground(DependencyObject obj)
+        {
+            return (Color)obj.GetValue(TitleBarForegroundProperty);
+        }
+
+        public static void SetTitleBarForeground(DependencyObject obj, Color value)
+        {
+            obj.SetValue(TitleBarForegroundProperty, value);
+        }
+
+        // Using a DependencyProperty as the backing store for TitleBarColor.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty TitleBarForegroundProperty =
+            DependencyProperty.RegisterAttached("TitleBarForeground", typeof(Color), typeof(AcrylicElement), new FrameworkPropertyMetadata(Colors.Black, FrameworkPropertyMetadataOptions.Inherits));
 
 
 

--- a/FluentWPF/Styles/Window.xaml
+++ b/FluentWPF/Styles/Window.xaml
@@ -79,6 +79,9 @@
                         <ContentPresenter x:Name="contentPresenter" Focusable="False"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                            <TextBlock.Foreground>
+                                <SolidColorBrush x:Name="brush" Color="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=(local:AcrylicWindow.TitleBarForeground)}"/>
+                            </TextBlock.Foreground>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -159,7 +162,7 @@
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                             <TextBlock.Foreground>
-                                <SolidColorBrush x:Name="brush" Color="Black"/>
+                                <SolidColorBrush x:Name="brush" Color="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=(local:AcrylicWindow.TitleBarForeground)}"/>
                             </TextBlock.Foreground>
                         </ContentPresenter>
                     </Grid>
@@ -222,7 +225,11 @@
                                 <TextBlock x:Name="captionText"
                                            Text="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Title}"
                                            Margin="8,0"
-                                           VerticalAlignment="Center"/>
+                                           VerticalAlignment="Center">
+                                            <TextBlock.Foreground>
+                                                <SolidColorBrush Color="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=(local:AcrylicWindow.TitleBarForeground)}" />
+                                            </TextBlock.Foreground>
+                                </TextBlock>
                                 <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                                     <Button x:Name="btnMinimizeButton" Content="&#xE921;" Style="{StaticResource GrayCaptionButtonStyleKey}" Command="{x:Static SystemCommands.MinimizeWindowCommand}" />
                                     <Button x:Name="btnMaximizeButton" Content="&#xE922;" Style="{StaticResource GrayCaptionButtonStyleKey}" Command="{x:Static SystemCommands.MaximizeWindowCommand}"/>


### PR DESCRIPTION
Aaah, I couldn't wait for help and did it myself.

Now AcrylicWindow will have fw:AcrylicWindow.TitleBarForeground property. It means that after changing default value, you will see that TitleBar's Title and Buttons will have another color. It's good if you use black background.

Default value: Black.