### PR TITLE
Fixed not calling EnableBlur() when enabling blur property after window opened.

### DIFF
--- a/FluentWPF/AcrylicWindow.cs
+++ b/FluentWPF/AcrylicWindow.cs
@@ -328,6 +328,7 @@ namespace SourceChord.FluentWPF
                 win.Style = style;
 
                 win.Loaded += (_, __) => { EnableBlur(win); };
+                if(win.IsLoaded) EnableBlur(win);
             }
         }
         #endregion


### PR DESCRIPTION
If the window is already loaded, the EnableBlur() function is not called and the blur effect seems not coming to effect.
I tried to change the Enabled property after the window loaded but the blur effect was not working so I wrote a simple one line fix.