### PR TITLE
Fixed issue that space for displaying caption was reserved even the caption was disabled.

### DIFF
--- a/FluentWPF/Styles/Window.xaml
+++ b/FluentWPF/Styles/Window.xaml
@@ -210,7 +210,7 @@
                         <!-- Title bar area -->
                         <Grid>
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="30"/>
+                                <RowDefinition Height="Auto"/>
                                 <RowDefinition />
                             </Grid.RowDefinitions>
                             <AdornerDecorator x:Name="windowContent"
@@ -219,6 +219,7 @@
                             </AdornerDecorator>
 
                             <Grid x:Name="captionGrid"
+                                  Height="30"
                                   Visibility="{Binding RelativeSource={RelativeSource AncestorType=Window},
                                                        Path=(local:AcrylicWindow.ShowTitleBar),
                                                        Converter={StaticResource BooleanToVisibilityConverter}}">


### PR DESCRIPTION
The grid `captionGrid` seems to be collapsed when setting `ShowTitleBar` property to `False` but the region for showing `captionGrid` is still shown.
I changed the Height value of RowDefinition to Auto and changing Height value of Grid(captionGrid) to 30 and the issue was gone.
Even after applying this patch, it was okay to use FluentWPF's caption bar with setting `ShowTitleBar` property to `True`.