### PR TITLE
Use default value if AppsUseLightTheme key does not exist

### DIFF
--- a/FluentWPF/Resources/SystemTheme.cs
+++ b/FluentWPF/Resources/SystemTheme.cs
@@ -49,7 +49,7 @@ namespace SourceChord.FluentWPF
             var regkey = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", false);
             // キーが存在しないときはnullが返る
             if (regkey == null) return ApplicationTheme.Light;
-            var intValue = (int)regkey.GetValue("AppsUseLightTheme");
+            var intValue = (int)regkey.GetValue("AppsUseLightTheme", 1);
 
             return intValue == 0 ? ApplicationTheme.Dark : ApplicationTheme.Light;
         }


### PR DESCRIPTION
Fix for https://github.com/sourcechord/FluentWPF/issues/11

That registry key does not exist on a clean Windows 10 1803 install