### PR TITLE
Added missing color and TextBlock styles

### DIFF
--- a/FluentWPF/Styles/Brushes.xaml
+++ b/FluentWPF/Styles/Brushes.xaml
@@ -12,6 +12,26 @@
     <SolidColorBrush x:Key="SystemAltMediumColorBrush" Color="{DynamicResource SystemAltMediumColor}" />
     <SolidColorBrush x:Key="SystemAltMediumHighColorBrush" Color="{DynamicResource SystemAltMediumHighColor}" />
     <SolidColorBrush x:Key="SystemAltHighColorBrush" Color="{DynamicResource SystemAltHighColor}" />
+    
+    <SolidColorBrush x:Key="SystemChromeLowColorBrush" Color="{DynamicResource SystemChromeLowColor}" />
+    <SolidColorBrush x:Key="SystemChromeMediumLowColorBrush" Color="{DynamicResource SystemChromeMediumLowColor}" />
+    <SolidColorBrush x:Key="SystemChromeMediumColorBrush" Color="{DynamicResource SystemChromeMediumColor}" />
+    <SolidColorBrush x:Key="SystemChromeHighColorBrush" Color="{DynamicResource SystemChromeHighColor}" />
+
+    <SolidColorBrush x:Key="SystemChromeAltLowColorBrush" Color="{DynamicResource SystemChromeAltLowColor}" />
+
+    <SolidColorBrush x:Key="SystemChromeBlackLowColorBrush" Color="{DynamicResource SystemChromeBlackLowColor}" />
+    <SolidColorBrush x:Key="SystemChromeBlackMediumLowColorBrush" Color="{DynamicResource SystemChromeBlackMediumLowColor}" />
+    <SolidColorBrush x:Key="SystemChromeBlackMediumColorBrush" Color="{DynamicResource SystemChromeBlackMediumColor}" />
+    <SolidColorBrush x:Key="SystemChromeBlackHighColorBrush" Color="{DynamicResource SystemChromeBlackHighColor}" />
+
+    <SolidColorBrush x:Key="SystemChromeDisabledLowColorBrush" Color="{DynamicResource SystemChromeDisabledLowColor}" />
+    <SolidColorBrush x:Key="SystemChromeDisabledHighColorBrush" Color="{DynamicResource SystemChromeDisabledHighColor}" />
+
+    <SolidColorBrush x:Key="SystemChromeWhiteColorBrush" Color="{DynamicResource SystemChromeWhiteColor}" />
+
+    <SolidColorBrush x:Key="SystemListLowColorBrush" Color="{DynamicResource SystemListLowColor}" />
+    <SolidColorBrush x:Key="SystemListMediumColorBrush" Color="{DynamicResource SystemListMediumColor}" />
 
 
     <SolidColorBrush x:Key="SystemControlWindowBrush" Color="{DynamicResource SystemAltHighColor}" />

--- a/FluentWPF/Styles/Colors.Dark.xaml
+++ b/FluentWPF/Styles/Colors.Dark.xaml
@@ -1,17 +1,40 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:SourceChord.FluentWPF">
+    <--! Base is for text. -->
     <Color x:Key="SystemBaseLowColor">#33FFFFFF</Color>
-    <Color x:Key="SystemBaseMediumLowColor">#66FFFFFF</Color>   <!-- for Disabled UI -->
-    <Color x:Key="SystemBaseMediumColor">#99FFFFFF</Color>      <!-- for Secondary text -->
+    <Color x:Key="SystemBaseMediumLowColor">#66FFFFFF</Color>
+    <Color x:Key="SystemBaseMediumColor">#99FFFFFF</Color>
     <Color x:Key="SystemBaseMediumHighColor">#CCFFFFFF</Color>
-    <Color x:Key="SystemBaseHighColor">#FFFFFFFF</Color>        <!-- for Primary text -->
+    <Color x:Key="SystemBaseHighColor">#FFFFFFFF</Color> <!-- for Primary text -->
 
+    <--! Alt is the inverse of Base. -->
     <Color x:Key="SystemAltLowColor">#33000000</Color>
     <Color x:Key="SystemAltMediumLowColor">#66000000</Color>
     <Color x:Key="SystemAltMediumColor">#99000000</Color>
     <Color x:Key="SystemAltMediumHighColor">#CC000000</Color>
-    <Color x:Key="SystemAltHighColor">#FF000000</Color>         <!-- for Content area -->
+    <Color x:Key="SystemAltHighColor">#FF000000</Color>
+
+    <--! Chrome is for top-level elements, such as navigation panes or command bars. -->
+    <Color x:Key="SystemChromeLowColor">#FF171717</Color>
+    <Color x:Key="SystemChromeMediumLowColor">#FF2B2B2B</Color>
+    <Color x:Key="SystemChromeMediumColor">#FF1F1F1F</Color> <--! Panel background color (e.g., ComboBox Popup) -->
+    <Color x:Key="SystemChromeHighColor">#FF767676</Color>
+
+    <Color x:Key="SystemChromeAltLowColor">#FFF2F2F2</Color>
+
+    <Color x:Key="SystemChromeBlackLowColor">#33000000</Color>
+    <Color x:Key="SystemChromeBlackMediumLowColor">#66000000</Color>
+    <Color x:Key="SystemChromeBlackMediumColor">#CC000000</Color>
+    <Color x:Key="SystemChromeBlackHighColor">#FF000000</Color> <--! TextBox foreground focused color -->
+
+    <Color x:Key="SystemChromeDisabledLowColor">#FF858585</Color>
+    <Color x:Key="SystemChromeDisabledHighColor">#FF333333</Color>
+
+    <Color x:Key="SystemChromeWhiteColor">#FFFFFFFF</Color> <--! TextBox background focused color -->
+
+    <Color x:Key="SystemListLowColor">#19FFFFFF</Color> <--! Hover list item -->
+    <Color x:Key="SystemListMediumColor">#33FFFFFF</Color> <--! Pressed list item -->
 
     <Color x:Key="SystemControlAcrylicWindowTintColor">#FF000000</Color>
     <Color x:Key="SystemControlAcrylicWindowFallbackColor">#FF1F1F1F</Color>

--- a/FluentWPF/Styles/Colors.Light.xaml
+++ b/FluentWPF/Styles/Colors.Light.xaml
@@ -1,17 +1,40 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:SourceChord.FluentWPF">
+    <--! Base is for text. -->
     <Color x:Key="SystemBaseLowColor">#33000000</Color>
-    <Color x:Key="SystemBaseMediumLowColor">#66000000</Color>   <!-- for Disabled UI -->
-    <Color x:Key="SystemBaseMediumColor">#99000000</Color>      <!-- for Secondary text -->
+    <Color x:Key="SystemBaseMediumLowColor">#66000000</Color>
+    <Color x:Key="SystemBaseMediumColor">#99000000</Color>
     <Color x:Key="SystemBaseMediumHighColor">#CC000000</Color>
-    <Color x:Key="SystemBaseHighColor">#FF000000</Color>        <!-- for Primary text -->
+    <Color x:Key="SystemBaseHighColor">#FF000000</Color> <!-- for Primary text -->
 
+    <--! Alt is the inverse of Base. -->
     <Color x:Key="SystemAltLowColor">#33FFFFFF</Color>
     <Color x:Key="SystemAltMediumLowColor">#66FFFFFF</Color>
     <Color x:Key="SystemAltMediumColor">#99FFFFFF</Color>
     <Color x:Key="SystemAltMediumHighColor">#CCFFFFFF</Color>
-    <Color x:Key="SystemAltHighColor">#FFFFFFFF</Color>         <!-- for Content area -->
+    <Color x:Key="SystemAltHighColor">#FFFFFFFF</Color>
+
+    <--! Chrome is for top-level elements, such as navigation panes or command bars. -->
+    <Color x:Key="SystemChromeLowColor">#FFF2F2F2</Color>
+    <Color x:Key="SystemChromeMediumLowColor">#FFF2F2F2</Color>
+    <Color x:Key="SystemChromeMediumColor">#FFE6E6E6</Color> <--! Panel background color (e.g., ComboBox Popup) -->
+    <Color x:Key="SystemChromeHighColor">#FFCCCCCC</Color>
+
+    <Color x:Key="SystemChromeAltLowColor">#FF171717</Color>
+
+    <Color x:Key="SystemChromeBlackLowColor">#33000000</Color>
+    <Color x:Key="SystemChromeBlackMediumLowColor">#66000000</Color>
+    <Color x:Key="SystemChromeBlackMediumColor">#CC000000</Color>
+    <Color x:Key="SystemChromeBlackHighColor">#FF000000</Color> <--! TextBox foreground focused color -->
+
+    <Color x:Key="SystemChromeDisabledLowColor">#FF7A7A7A</Color>
+    <Color x:Key="SystemChromeDisabledHighColor">#FFCCCCCC</Color>
+
+    <Color x:Key="SystemChromeWhiteColor">#FFFFFFFF</Color> <--! TextBox background focused color -->
+
+    <Color x:Key="SystemListLowColor">#19000000</Color> <--! Hover list item -->
+    <Color x:Key="SystemListMediumColor">#33000000</Color> <--! Pressed list item -->
 
     <Color x:Key="SystemControlAcrylicWindowTintColor">#FFFFFFFF</Color>
     <Color x:Key="SystemControlAcrylicWindowFallbackColor">#FFE6E6E6</Color>

--- a/FluentWPF/Styles/Controls.xaml
+++ b/FluentWPF/Styles/Controls.xaml
@@ -7,6 +7,7 @@
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/ListBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/ScrollBar.xaml" />
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/TextBox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/TextBlock.xaml" />
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/Window.xaml" />
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/Menu.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/FluentWPF/Styles/TextBlock.xaml
+++ b/FluentWPF/Styles/TextBlock.xaml
@@ -1,0 +1,53 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:SourceChord.FluentWPF">
+    <Style x:Key="BaseTextBlockStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="Segoe UI"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="TextTrimming" Value="None"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="LineStackingStrategy" Value="MaxHeight"/>
+        <Setter Property="TextLineBounds" Value="Full"/>
+    </Style>
+
+    <Style x:Key="HeaderTextBlockStyle" TargetType="TextBlock"
+           BasedOn="{StaticResource BaseTextBlockStyle}">
+        <Setter Property="FontSize" Value="46"/>
+        <Setter Property="FontWeight" Value="Light"/>
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings"/>
+    </Style>
+
+    <Style x:Key="SubheaderTextBlockStyle" TargetType="TextBlock" 
+           BasedOn="{StaticResource BaseTextBlockStyle}">
+        <Setter Property="FontSize" Value="34"/>
+        <Setter Property="FontWeight" Value="Light"/>
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings"/>
+    </Style>
+
+    <Style x:Key="TitleTextBlockStyle" TargetType="TextBlock" 
+           BasedOn="{StaticResource BaseTextBlockStyle}">
+        <Setter Property="FontWeight" Value="SemiLight"/>
+        <Setter Property="FontSize" Value="24"/>
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings"/>
+    </Style>
+
+    <Style x:Key="SubtitleTextBlockStyle" TargetType="TextBlock" 
+           BasedOn="{StaticResource BaseTextBlockStyle}">
+        <Setter Property="FontWeight" Value="Normal"/>
+        <Setter Property="FontSize" Value="20"/>
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings"/>
+    </Style>
+
+    <Style x:Key="BodyTextBlockStyle" TargetType="TextBlock" 
+           BasedOn="{StaticResource BaseTextBlockStyle}">
+        <Setter Property="FontWeight" Value="Normal"/>
+        <Setter Property="FontSize" Value="14"/>
+    </Style>
+
+    <Style x:Key="CaptionTextBlockStyle" TargetType="TextBlock" 
+           BasedOn="{StaticResource BaseTextBlockStyle}">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontWeight" Value="Normal"/>
+    </Style>
+</ResourceDictionary>

--- a/README.md
+++ b/README.md
@@ -346,6 +346,42 @@ _Accent color depends on the accent color of the system._
  <TextBlock Foreground="{DynamicResource SystemAltHighColorBrush}"/>
 ```
 
+#### Chrome Color
+
+|Light|Dark|Color|Brush|
+|-----|-----|-----|-----|
+|![#CCCCCC](https://placehold.it/30/CCCCCC/000000?text=+)|![#767676](https://placehold.it/30/767676/000000?text=+)|SystemChromeHighColor|SystemChromeHighColorBrush|
+|![#E6E6E6](https://placehold.it/30/E6E6E6/000000?text=+)|![#1F1F1F](https://placehold.it/30/1F1F1F/000000?text=+)|SytemAltMediumColor|SytemAltMediumColorBrush|
+|![#F2F2F2](https://placehold.it/30/F2F2F2/000000?text=+)|![#2B2B2B](https://placehold.it/30/2B2B2B/000000?text=+)|SystemChromeMediumLowColor|SystemChromeMediumLowColorBrush|
+|![#F2F2F2](https://placehold.it/30/F2F2F2/000000?text=+)|![#171717](https://placehold.it/30/171717/000000?text=+)|SystemChromeLowColor|SystemChromeLowColorBrush|
+
+**Usage:**
+```xml
+ <Border Background="{DynamicResource SystemChromeMediumBrush}"/>
+```
+
+#### Opacity Color
+
+Windows includes a set of colors that differ only by their opacities:
+
+|Base Color|Opacity|Color|Brush|
+|-----|-----|-----|-----|
+|![#000000](https://placehold.it/30/000000/000000?text=+)|FF|SystemChromeBlackHighColor|SystemChromeBlackHighColorBrush|
+|![#000000](https://placehold.it/30/000000/000000?text=+)|CC|SystemChromeBlackMediumColor|SystemChromeBlackMediumColor|
+|![#000000](https://placehold.it/30/000000/000000?text=+)|66|SystemChromeBlackMediumLowColor|SystemChromeBlackMediumLowColorBrush|
+|![#000000](https://placehold.it/30/000000/000000?text=+)|33|SystemChromeBlackLowColor|SystemChromeBlackLowColorBrush|
+|![#FFFFFF](https://placehold.it/30/FFFFFF/000000?text=+)|33|SystemListMediumColor|SystemListMediumColorBrush|
+|![#FFFFFF](https://placehold.it/30/FFFFFF/000000?text=+)|19|SystemListLowColor|SystemListLowColorBrush|
+
+
+#### Other Colors
+
+|Light|Dark|Color|Brush|
+|-----|-----|-----|-----|
+|![#FFFFFF](https://placehold.it/30/FFFFFF/000000?text=+)|![#FFFFFF](https://placehold.it/30/FFFFFF/000000?text=+)|SystemChromeWhiteColor|SystemChromeWhiteColorBrush|
+|![#171717](https://placehold.it/30/171717/000000?text=+)|![#F2F2F2](https://placehold.it/30/F2F2F2/000000?text=+)|SystemChromeAltLowColor|SystemChromeAltLowColorBrush|
+|![#CCCCCC](https://placehold.it/30/CCCCCC/000000?text=+)|![#333333](https://placehold.it/30/333333/000000?text=+)|SystemChromeDisabledHighColor|SystemChromeDisabledHighColorBrush|
+|![#7A7A7A](https://placehold.it/30/7A7A7A/000000?text=+)|![#858585](https://placehold.it/30/858585/000000?text=+)|SystemChromeDisabledLowColor|SystemChromeDisabledLowColorBrush|
 
 
 


### PR DESCRIPTION
I added some colours that were missing (taken from [here](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/xaml-theme-resources#the-xaml-color-ramp-and-theme-dependent-brushes)).

Where possible, I added a small description to colours (directly into the XAML) as per this [article](https://docs.microsoft.com/en-us/windows/uwp/design/style/color#theme-brushes).

Finally, I added some `TextBlock` styles (e.g., Header, Title, Body, etc.), taken from [here](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/xaml-theme-resources#the-xaml-type-ramp).