### PR TITLE
Combobox Styles

### DIFF
--- a/FluentWPF/FluentWPF.csproj
+++ b/FluentWPF/FluentWPF.csproj
@@ -5,6 +5,8 @@
     <TargetFrameworks>net45;netcoreapp3.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>SourceChord.FluentWPF</RootNamespace>
+    
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -96,15 +96,17 @@
         <Setter Property="Background" Value="{DynamicResource SystemAltMediumLowColorBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource SystemBaseMediumLowColorBrush}" />
         <Setter Property="BorderThickness" Value="{StaticResource ComboBoxBorderThemeThickness}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="UseLayoutRounding" Value="True" />
         <Setter Property="KeyboardNavigation.TabNavigation" Value="Once" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
-        <Setter Property="HorizontalAlignment" Value="Stretch" />
-        <Setter Property="VerticalAlignment" Value="Stretch" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="FontFamily" Value="{StaticResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="{StaticResource ControlContentThemeFontSize}" />
         <Setter Property="local:RevealElement.MouseOverForeground" Value="{DynamicResource SystemBaseHighColorBrush}" />
@@ -208,7 +210,7 @@
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Border BorderThickness="2" BorderBrush="{DynamicResource SystemBaseHighColorBrush" />
+                    <Border BorderThickness="2" BorderBrush="{DynamicResource SystemBaseHighColorBrush}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -228,8 +230,6 @@
         <Setter Property="KeyboardNavigation.ControlTabNavigation" Value="None" />
         <Setter Property="KeyboardNavigation.TabNavigation" Value="Local" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource ComboBoxItemFocusVisualStyle}" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="UseLayoutRounding" Value="True" />
         <EventSetter Event="PreviewMouseLeftButtonDown" Handler="ComboBoxItem_PreviewMouseLeftButtonDown" />
         <Setter Property="Template">
             <Setter.Value>
@@ -352,6 +352,22 @@
 
                                         <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="brush"
                                                          To="0" BeginTime="0:0:0.200" Duration="0:0:2.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="border"
+                                                         To="0" Duration="0:0:0.000"/>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX" Storyboard.TargetName="itemRoot"
+                                                         To="0.975" Duration="0:0:0.100">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY" Storyboard.TargetName="itemRoot"
+                                                         To="0.975" Duration="0:0:0.100">
                                             <DoubleAnimation.EasingFunction>
                                                 <SineEase EasingMode="EaseInOut"/>
                                             </DoubleAnimation.EasingFunction>
@@ -485,7 +501,14 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
-                        <Grid>
+                        <Grid x:Name="itemRoot">
+                            <Grid.RenderTransformOrigin>
+                                <Point X="0.5" Y="0.5"/>
+                            </Grid.RenderTransformOrigin>
+                            <Grid.RenderTransform>
+                                <ScaleTransform ScaleX="1.0" ScaleY="1.0"/>
+                            </Grid.RenderTransform>
+
                             <!-- MouseOver border -->
                             <Grid x:Name="border" Visibility="Hidden">
                                 <Border x:Name="borderMouseOver"

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -8,6 +8,7 @@
             <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
             <Thickness x:Key="FocusThickness">2</Thickness>
         </ResourceDictionary>
+        <ResourceDictionary Source="TextBox.xaml" />
         <local:ResourceDictionaryEx>
             <local:ResourceDictionaryEx.ThemeDictionaries>
                 <local:ThemeDictionary ThemeName="Light">

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -172,10 +172,12 @@
                         </VisualStateManager.VisualStateGroups>
                         <ToggleButton x:Name="ToggleButton"                        
                                       Template="{StaticResource ComboBoxToggleButton}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, FallbackValue=1}"
                                       Grid.Column="2"
                                       Focusable="True"
                                       ClickMode="Release"
-                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
                         <TextBox x:Name="PART_EditableTextBox"
                                  Style="{StaticResource TextBoxRevealStyle}"
                                  BorderThickness="0"

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -9,6 +9,7 @@
             <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
         </ResourceDictionary>
         <ResourceDictionary Source="TextBox.xaml" />
+        <ResourceDictionary Source="ScrollBar.xaml" />
         <!-- TODO: Changing system theme while running doesn't change brush -->
         <local:ResourceDictionaryEx>
             <local:ResourceDictionaryEx.ThemeDictionaries>
@@ -102,6 +103,44 @@
                 Focusable="False"
                 Background="{TemplateBinding Background}" />
     </ControlTemplate>
+    
+    <Style x:Key="ComboboxScrollViewer" TargetType="{x:Type ScrollViewer}">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Border>
+                            <ScrollContentPresenter />
+                        </Border>
+                        <ScrollBar x:Name="PART_VerticalScrollBar"
+                                   Grid.Column="1" 
+                                   Value="{TemplateBinding VerticalOffset}"
+                                   Maximum="{TemplateBinding ScrollableHeight}"
+                                   ViewportSize="{TemplateBinding ViewportHeight}"
+                                   Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                                   Style="{StaticResource ScrollBarStyle1}" />
+                        <ScrollBar x:Name="PART_HorizontalScrollBar"
+                                   Orientation="Horizontal"
+                                   Grid.Row="1"
+                                   Value="{TemplateBinding HorizontalOffset}"
+                                   Maximum="{TemplateBinding ScrollableWidth}"
+                                   ViewportSize="{TemplateBinding ViewportWidth}"
+                                   Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+                                   Style="{StaticResource ScrollBarStyle1}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
     <Style x:Key="ComboBoxRevealStyle" TargetType="{x:Type ComboBox}">
         <Setter Property="Padding" Value="12,5,0,7" />
@@ -185,6 +224,7 @@
                                Placement="Relative"
                                PlacementRectangle="0,-5,0,0"
                                Focusable="False"
+                               MaxHeight="300"
                                AllowsTransparency="True"
                                PopupAnimation="Fade">
                             <Border x:Name="PopupBorder"
@@ -202,12 +242,13 @@
                                         </Rectangle.Fill>
                                     </Rectangle>
                                     <ScrollViewer x:Name="ScrollViewer"
-                                                    Margin="0,4,0,4"
-                                                    Foreground="{DynamicResource SystemBaseHighColorBrush}"
-                                                    HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                    VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                                    CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
-                                                    IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}">
+                                                  Margin="0,4,0,4"
+                                                  Foreground="{DynamicResource SystemBaseHighColorBrush}"
+                                                  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                                  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                                  CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                                                  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                                                  Style="{StaticResource ComboboxScrollViewer}">
                                         <StackPanel IsItemsHost="True"
                                                     KeyboardNavigation.DirectionalNavigation="Contained"/>
                                     </ScrollViewer>

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -74,6 +74,19 @@
                         </Storyboard>
                     </VisualState>
                 </VisualStateGroup>
+                <VisualStateGroup x:Name="CheckStates">
+                    <VisualState x:Name="Checked">
+                        <Storyboard>
+                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListMediumColorBrush}" />
+                            </ObjectAnimationUsingKeyFrames>
+                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColorBrush}" />
+                            </ObjectAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="Unchecked" />
+                </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>
         <ControlTemplate.Triggers>

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -3,20 +3,36 @@
                     x:Class="SourceChord.FluentWPF.ComboBoxResourceDictionary"
                     xmlns:local="clr-namespace:SourceChord.FluentWPF" >
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary>
+            <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
+            <Thickness x:Key="FocusThickness">2</Thickness>
+        </ResourceDictionary>
+        <local:ResourceDictionaryEx>
+            <local:ResourceDictionaryEx.ThemeDictionaries>
+                <local:ThemeDictionary ThemeName="Light">
+                    <local:ThemeDictionary.MergedDictionaries>
+                        <ResourceDictionary>
+                            <SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.7" />
+                            <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.6" />
+                            <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.4" />
+                        </ResourceDictionary>
+                    </local:ThemeDictionary.MergedDictionaries>
+                </local:ThemeDictionary>
+                <local:ThemeDictionary ThemeName="Dark">
+                    <local:ThemeDictionary.MergedDictionaries>
+                        <ResourceDictionary>
+                            <SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.9" />
+                            <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.8" />
+                            <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.6" />
+                        </ResourceDictionary>
+                    </local:ThemeDictionary.MergedDictionaries>
+                </local:ThemeDictionary>
+            </local:ResourceDictionaryEx.ThemeDictionaries>
+        </local:ResourceDictionaryEx>
+    </ResourceDictionary.MergedDictionaries>
+
     <local:ComboBoxItemVisualStateManager x:Key="ComboBoxItemVisualStateManager" />
-
-    <!--0.4 is for light theme-->
-    <!--<SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.4" />-->
-    <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.6" />
-    <!--0.6 is for light theme-->
-    <!--<SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.6" />-->
-    <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.8" />
-    <!--0.7 is for light theme-->
-    <!--<SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.7" />-->
-    <SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.9" />
-
-    <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
-    <Thickness x:Key="FocusThickness">2</Thickness>
 
     <ControlTemplate x:Key="ComboBoxToggleButton" TargetType="{x:Type ToggleButton}">
         <Grid>

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -5,6 +5,7 @@
                     xmlns:converters="clr-namespace:SourceChord.FluentWPF.Converters">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary>
+            <Thickness x:Key="ComboBoxBorderThemeThickness">2.5</Thickness>
             <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
         </ResourceDictionary>
         <ResourceDictionary Source="TextBox.xaml" />
@@ -595,7 +596,7 @@
                             <Border BorderBrush="{x:Null}"
                                     Margin="{TemplateBinding BorderThickness}"
                                     Padding="{TemplateBinding Padding}"
-                                    CornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Button}, Path=(local:RevealElement.BorderRadius)}">
+                                    CornerRadius="{Binding  RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}">
                                 <ContentPresenter x:Name="ContentPresenter"
                                                   Content="{TemplateBinding Content}"
                                                   ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -1,31 +1,31 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:Class="SourceChord.FluentWPF.ComboBoxResourceDictionary"
-                    xmlns:local="clr-namespace:SourceChord.FluentWPF" >
-
+                    xmlns:local="clr-namespace:SourceChord.FluentWPF"
+                    xmlns:converters="clr-namespace:SourceChord.FluentWPF.Converters">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary>
             <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
-            <Thickness x:Key="FocusThickness">2</Thickness>
         </ResourceDictionary>
         <ResourceDictionary Source="TextBox.xaml" />
+        <!-- TODO: Changing system theme while running doesn't change brush -->
         <local:ResourceDictionaryEx>
             <local:ResourceDictionaryEx.ThemeDictionaries>
                 <local:ThemeDictionary ThemeName="Light">
                     <local:ThemeDictionary.MergedDictionaries>
                         <ResourceDictionary>
-                            <SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.7" />
-                            <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.6" />
-                            <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.4" />
+                            <SolidColorBrush x:Key="ImmersiveSystemAccent3Brush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccentLight3)}"/>
+                            <SolidColorBrush x:Key="ImmersiveSystemAccent2Brush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccentLight2)}"/>
+                            <SolidColorBrush x:Key="DropdownBorderBrush" Color="{DynamicResource SystemChromeHighColor}"/>
                         </ResourceDictionary>
                     </local:ThemeDictionary.MergedDictionaries>
                 </local:ThemeDictionary>
                 <local:ThemeDictionary ThemeName="Dark">
                     <local:ThemeDictionary.MergedDictionaries>
                         <ResourceDictionary>
-                            <SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.9" />
-                            <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.8" />
-                            <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.6" />
+                            <SolidColorBrush x:Key="ImmersiveSystemAccent3Brush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccentDark3)}"/>
+                            <SolidColorBrush x:Key="ImmersiveSystemAccent2Brush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccentDark2)}"/>
+                            <SolidColorBrush x:Key="DropdownBorderBrush" Color="{DynamicResource SystemChromeLowColor}"/>
                         </ResourceDictionary>
                     </local:ThemeDictionary.MergedDictionaries>
                 </local:ThemeDictionary>
@@ -34,6 +34,9 @@
     </ResourceDictionary.MergedDictionaries>
 
     <local:ComboBoxItemVisualStateManager x:Key="ComboBoxItemVisualStateManager" />
+    <local:RelativePositionConverter x:Key="relativePositionConverter" />
+    <converters:HeightToRadiusConverter x:Key="HeightToRadiusConverter" />
+    <converters:RectConverter x:Key="RectConverter" />
 
     <ControlTemplate x:Key="ComboBoxToggleButton" TargetType="{x:Type ToggleButton}">
         <Grid>
@@ -41,81 +44,12 @@
                 <ColumnDefinition />
                 <ColumnDefinition Width="32" />
             </Grid.ColumnDefinitions>
-            <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="Normal" />
-                    <VisualState x:Name="MouseOver">
-                        <Storyboard>
-                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush.Color">
-                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumColor}" />
-                            </ColorAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                    <VisualState x:Name="Pressed">
-                        <Storyboard>
-                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
-                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListMediumColorBrush}" />
-                            </ObjectAnimationUsingKeyFrames>
-                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush.Color">
-                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColor}" />
-                            </ColorAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                    <VisualState x:Name="Disabled">
-                        <Storyboard>
-                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
-                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseLowColorBrush}" />
-                            </ObjectAnimationUsingKeyFrames>
-                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush.Color">
-                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColor}" />
-                            </ColorAnimationUsingKeyFrames>
-                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph" Storyboard.TargetProperty="Foreground.Color">
-                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColor}" />
-                            </ColorAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                </VisualStateGroup>
-                <VisualStateGroup x:Name="CheckStates">
-                    <VisualState x:Name="Checked">
-                        <Storyboard>
-                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
-                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListMediumColorBrush}" />
-                            </ObjectAnimationUsingKeyFrames>
-                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush.Color">
-                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColor}" />
-                            </ColorAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                    <VisualState x:Name="Unchecked" />
-                </VisualStateGroup>
-                <VisualStateGroup x:Name="FocusStates">
-                    <VisualState x:Name="Focused">
-                        <Storyboard>
-                            <DoubleAnimation Storyboard.TargetName="HighlightBackground" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
-                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="HighlightBackground" Storyboard.TargetProperty="BorderBrush.Color">
-                                <DiscreteColorKeyFrame KeyTime="0" Value="Transparent" />
-                            </ColorAnimationUsingKeyFrames>
-                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph" Storyboard.TargetProperty="Foreground.Color">
-                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumHighColor}" />
-                            </ColorAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                    <VisualState x:Name="Unfocused" />
-                </VisualStateGroup>
-            </VisualStateManager.VisualStateGroups>
             <Border x:Name="Background"
                     Grid.Row="1"
                     Grid.ColumnSpan="2"
                     Background="{DynamicResource SystemAltMediumColorBrush}"
                     BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"/>
-            <Border x:Name="HighlightBackground"
-                    Grid.Row="1"
-                    Grid.ColumnSpan="2"
-                    Background="{DynamicResource SystemListMediumColorBrush}"
-                    BorderBrush="{DynamicResource SystemBaseMediumLowColorBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    Opacity="0" />
+                    BorderThickness="{TemplateBinding BorderThickness}" />
             <TextBlock x:Name="DropDownGlyph"
                        Grid.Column="1"
                        IsHitTestVisible="False"
@@ -125,8 +59,28 @@
                        FontSize="12"
                        Text="&#xE0E5;"
                        HorizontalAlignment="Right"
-                       VerticalAlignment="Center" />
+                       VerticalAlignment="Center"/>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="Pressed">
+                        <Storyboard>
+                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseLowColorBrush}" />
+                            </ObjectAnimationUsingKeyFrames>
+                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColorBrush}" />
+                            </ObjectAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
         </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Background" Property="BorderBrush" Value="{DynamicResource SystemBaseMediumColorBrush}"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="ComboBoxTextBox" TargetType="{x:Type TextBox}">
@@ -135,7 +89,7 @@
                 Background="{TemplateBinding Background}" />
     </ControlTemplate>
 
-    <Style x:Key="FluentComboBox" TargetType="{x:Type ComboBox}">
+    <Style x:Key="ComboBoxRevealStyle" TargetType="{x:Type ComboBox}">
         <Setter Property="Padding" Value="12,5,0,7" />
         <Setter Property="MinWidth" Value="64" />
         <Setter Property="Foreground" Value="{DynamicResource SystemBaseHighColorBrush}" />
@@ -145,12 +99,21 @@
         <Setter Property="KeyboardNavigation.TabNavigation" Value="Once" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
-        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="FontFamily" Value="{StaticResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="{StaticResource ControlContentThemeFontSize}" />
+        <Setter Property="local:RevealElement.MouseOverForeground" Value="{DynamicResource SystemBaseHighColorBrush}" />
+        <Setter Property="local:RevealElement.BorderOpacity" Value="0"/>
+        <Setter Property="local:RevealElement.MouseOverBorderOpacity" Value="0.1" />
+        <Setter Property="local:RevealElement.PressBorderOpacity" Value="0.2" />
+        <Setter Property="local:RevealElement.BorderRadius" Value="0" />
+        <Setter Property="local:RevealElement.PressTintBrush" Value="{DynamicResource SystemBaseLowColorBrush}" />
+
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBox}">
@@ -170,14 +133,6 @@
                                 <VisualState x:Name="Uneditable" />
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <ToggleButton x:Name="ToggleButton"                        
-                                      Template="{StaticResource ComboBoxToggleButton}"
-                                      BorderBrush="{TemplateBinding BorderBrush}"
-                                      BorderThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, FallbackValue=1}"
-                                      Grid.Column="2"
-                                      Focusable="True"
-                                      ClickMode="Release"
-                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
                         <TextBox x:Name="PART_EditableTextBox"
                                  Style="{StaticResource TextBoxRevealStyle}"
                                  BorderThickness="0"
@@ -185,9 +140,18 @@
                                  Margin="0 0 32 0"
                                  HorizontalAlignment="Left"
                                  VerticalAlignment="Center"
+                                 TextAlignment="Center"
                                  Focusable="True"
                                  Visibility="Hidden"
                                  IsReadOnly="{TemplateBinding IsReadOnly}" />
+                        <ToggleButton x:Name="ToggleButton"
+                                      Template="{StaticResource ComboBoxToggleButton}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, FallbackValue=1}"
+                                      Grid.Column="2"
+                                      Focusable="True"
+                                      ClickMode="Release"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
                         <ContentPresenter x:Name="ContentSite"
                                           IsHitTestVisible="False"
                                           Content="{TemplateBinding SelectionBoxItem}"
@@ -196,27 +160,42 @@
                                           TextBlock.Foreground="{DynamicResource SystemBaseHighColorBrush}"
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+
+                        <!-- TODO: Popup offset according to SelectedIndex, PlacementRectangle=0,x,0,0 / x=-5-(ComboBox.SelectedIndex)*(ComboBoxItem.Height) -->
                         <Popup x:Name="Popup"
                                IsOpen="{TemplateBinding IsDropDownOpen}"
+                               Width="{TemplateBinding Width}"
+                               Placement="Relative"
+                               PlacementRectangle="0,-5,0,0"
                                Focusable="False"
-                               PopupAnimation="Slide">
+                               AllowsTransparency="True"
+                               PopupAnimation="Fade">
                             <Border x:Name="PopupBorder"
-                                Background="{DynamicResource SystemChromeMediumLowColorBrush}"
-                                BorderBrush="{DynamicResource SystemChromeHighColorBrush}"
-                                BorderThickness="1"
-                                Margin="0,-1,0,-1"
-                                HorizontalAlignment="Stretch">
-                                <ScrollViewer x:Name="ScrollViewer"
-                                              Foreground="{DynamicResource SystemBaseHighColorBrush}"
-                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                              IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-                                              MinWidth="{TemplateBinding Width}">
-                                    <StackPanel IsItemsHost="True"
-                                                KeyboardNavigation.DirectionalNavigation="Contained" 
-                                                Margin="0,7,0,7" />
-                                </ScrollViewer>
+                                    Background="{DynamicResource SystemChromeMediumColorBrush}"
+                                    BorderBrush="{DynamicResource DropdownBorderBrush}"
+                                    BorderThickness="1"
+                                    HorizontalAlignment="Stretch">
+                                <Grid>
+                                    <!-- Tiled noise texture -->
+                                    <Rectangle Margin="-1" x:Name="noiseLayer" Opacity="0.01">
+                                        <Rectangle.Fill>
+                                            <ImageBrush ImageSource="/FluentWPF;component/Assets/Images/noise.png"
+                                                        TileMode="Tile" Stretch="None"
+                                                        ViewportUnits="Absolute" Viewport="0,0,128,128"/>
+                                        </Rectangle.Fill>
+                                    </Rectangle>
+                                    <ScrollViewer x:Name="ScrollViewer"
+                                                    Margin="0,4,0,4"
+                                                    Foreground="{DynamicResource SystemBaseHighColorBrush}"
+                                                    HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                                    VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                                    CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                                                    IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}">
+                                        <StackPanel IsItemsHost="True"
+                                                    KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                    </ScrollViewer>
+                                </Grid>
                             </Border>
                         </Popup>
                     </Grid>
@@ -229,7 +208,7 @@
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Border BorderThickness="2" BorderBrush="{DynamicResource SystemBaseHighColorBrush}" />
+                    <Border BorderThickness="2" BorderBrush="Black" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -237,46 +216,74 @@
 
     <Style x:Key="{x:Type ComboBoxItem}" TargetType="{x:Type ComboBoxItem}">
         <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Height" Value="32"/><!-- absolute or relative? -->
+        <Setter Property="Padding" Value="10,0,10,0"/>
         <Setter Property="Foreground" Value="{DynamicResource SystemBaseHighColorBrush}" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="KeyboardNavigation.TabNavigation" Value="Local" />
-        <Setter Property="Padding" Value="11,5,11,7" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SystemBaseMediumHighColorBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="10,5,10,6" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="KeyboardNavigation.ControlTabNavigation" Value="None" />
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="Local" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource ComboBoxItemFocusVisualStyle}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="UseLayoutRounding" Value="True" />
         <EventSetter Event="PreviewMouseLeftButtonDown" Handler="ComboBoxItem_PreviewMouseLeftButtonDown" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBoxItem}">
                     <Border x:Name="LayoutRoot"
-                            MouseEnter="LayoutRoot_MouseEnter"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                            Height="{TemplateBinding Height}"
+                            MouseEnter="LayoutRoot_MouseEnter">
                         <VisualStateManager.CustomVisualStateManager>
                             <local:ComboBoxItemVisualStateManager />
                         </VisualStateManager.CustomVisualStateManager>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="FluentCommonStates">
-                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Normal">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="backgroundBorder"
+                                                         To="0.0" Duration="0:0:0.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="pressLight"
+                                                         To="0" Duration="0:0:0.100">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                    </Storyboard>
+                                </VisualState>
                                 <VisualState x:Name="PointerOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListLowColorBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="backgroundBorder"
+                                                         To="0.5" Duration="0:0:0.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusX)" Storyboard.TargetName="brush"
+                                                         To="200" Duration="0:0:0.200">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusY)" Storyboard.TargetName="brush"
+                                                         To="200" Duration="0:0:0.200">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Disabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="background" Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
@@ -286,39 +293,85 @@
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListMediumColorBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderThickness">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource FocusThickness}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="backgroundBorder"
+                                                         To="0.5" Duration="0:0:0.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="pressLight"
+                                                         To="1" Duration="0:0:0.100">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="pressLight"
+                                                         To="0" BeginTime="0:0:0.150" Duration="0:0:1.500">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusX)" Storyboard.TargetName="brush"
+                                                         From="100" To="50" Duration="0:0:0.100">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusX)" Storyboard.TargetName="brush"
+                                                         To="200" BeginTime="0:0:0.150" Duration="0:0:1.500">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusY)" Storyboard.TargetName="brush"
+                                                         From="100" To="50" Duration="0:0:0.100">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusY)" Storyboard.TargetName="brush"
+                                                         To="200" BeginTime="0:0:0.150" Duration="0:0:1.500">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="Offset" Storyboard.TargetName="offset"
+                                                         To="0" Duration="0:0:0.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="Offset" Storyboard.TargetName="offset"
+                                                         From="0" To="0.8" BeginTime="0:0:0.150" Duration="0:0:1.500">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="brush"
+                                                         To="0" BeginTime="0:0:0.200" Duration="0:0:2.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="pressTintLayer" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Selected">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="background" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource ImmersiveSystemAccent3Brush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="SelectedDisabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="background" Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
@@ -328,41 +381,208 @@
                                 </VisualState>
                                 <VisualState x:Name="SelectedPointerOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemControlHighlightListAccentMediumBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="backgroundBorder"
+                                                         To="0.5" Duration="0:0:0.000">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <CubicEase EasingMode="EaseOut"/>
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+
+                                            <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusX)" Storyboard.TargetName="brush"
+                                                         To="200" Duration="0:0:0.200">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <SineEase EasingMode="EaseInOut"/>
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                            <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusY)" Storyboard.TargetName="brush"
+                                                         To="200" Duration="0:0:0.200">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <SineEase EasingMode="EaseInOut"/>
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                        </Storyboard>
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="background" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource ImmersiveSystemAccent2Brush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="SelectedPressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemControlHighlightListAccentHighBrush}" />
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="backgroundBorder"
+                                                         To="0.5" Duration="0:0:0.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="pressLight"
+                                                         To="1" Duration="0:0:0.100">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="pressLight"
+                                                         To="0" BeginTime="0:0:0.150" Duration="0:0:1.500">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusX)" Storyboard.TargetName="brush"
+                                                         From="100" To="50" Duration="0:0:0.100">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusX)" Storyboard.TargetName="brush"
+                                                         To="200" BeginTime="0:0:0.150" Duration="0:0:1.500">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusY)" Storyboard.TargetName="brush"
+                                                         From="100" To="50" Duration="0:0:0.100">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="(RadialGradientBrush.RadiusY)" Storyboard.TargetName="brush"
+                                                         To="200" BeginTime="0:0:0.150" Duration="0:0:1.500">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="Offset" Storyboard.TargetName="offset"
+                                                         To="0" Duration="0:0:0.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="Offset" Storyboard.TargetName="offset"
+                                                         From="0" To="0.8" BeginTime="0:0:0.150" Duration="0:0:1.500">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="brush"
+                                                         To="0" BeginTime="0:0:0.200" Duration="0:0:2.000">
+                                            <DoubleAnimation.EasingFunction>
+                                                <SineEase EasingMode="EaseInOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="pressTintLayer" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="background" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource ImmersiveSystemAccent2Brush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <ContentPresenter x:Name="ContentPresenter"
-                                          Content="{TemplateBinding Content}"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                          TextBlock.Foreground="{TemplateBinding Foreground}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Margin="{TemplateBinding Padding}"
-                                          Focusable="False" />
+
+                        <Grid>
+                            <!-- MouseOver border -->
+                            <Grid x:Name="border" Visibility="Hidden">
+                                <Border x:Name="borderMouseOver"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        Visibility="Hidden"
+                                        Opacity="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderOpacity)}"
+                                        CornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}"/>
+
+                                <Border BorderBrush="{TemplateBinding BorderBrush}"
+                                        OpacityMask="{local:RevealBrush Color=White,Size=70,Opacity=0.3}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}"/>
+                            </Grid>
+
+                            <!-- Background -->
+                            <Border x:Name="background"
+                                    Background="{TemplateBinding Background}"
+                                    Margin="{TemplateBinding BorderThickness}"
+                                    CornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}"/>
+                            <Border x:Name="pressTintLayer"
+                                    Background="Transparent"
+                                    Margin="{TemplateBinding BorderThickness}"
+                                    CornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}"
+                                    Visibility="Visible"/>
+                            <Border x:Name="backgroundBorder"
+                                    Opacity="0"
+                                    Margin="{TemplateBinding BorderThickness}"
+                                    CornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}">
+                                <Grid ClipToBounds="True">
+                                    <Border x:Name="mouseoverLight" Background="{local:RevealBrush Color=White, Size = 300,Opacity=0.2}" Visibility="Hidden"
+                                            CornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}"/>
+                                    <Rectangle x:Name="pressLight" Opacity="0">
+                                        <Rectangle.Clip>
+                                            <RectangleGeometry RadiusX="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}"
+                                                               RadiusY="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.BorderRadius)}">
+                                                <RectangleGeometry.Rect>
+                                                    <MultiBinding Converter="{StaticResource RectConverter}">
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Rectangle}}" Path="ActualWidth"/>
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Rectangle}}" Path="ActualHeight"/>
+                                                    </MultiBinding>
+                                                </RectangleGeometry.Rect>
+                                            </RectangleGeometry>
+                                        </Rectangle.Clip>
+                                        <Rectangle.Fill>
+                                            <RadialGradientBrush x:Name="brush" MappingMode="Absolute" RadiusY="200" RadiusX="200">
+                                                <RadialGradientBrush.Center>
+                                                    <MultiBinding Converter="{StaticResource relativePositionConverter}">
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Rectangle}}" Path="(local:PointerTracker.RootObject)"/>
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Rectangle}}"/>
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Rectangle}}" Path="(local:PointerTracker.Position)" />
+                                                    </MultiBinding>
+                                                </RadialGradientBrush.Center>
+                                                <RadialGradientBrush.GradientOrigin>
+                                                    <MultiBinding Converter="{StaticResource relativePositionConverter}">
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Rectangle}}" Path="(local:PointerTracker.RootObject)"/>
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Rectangle}}"/>
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type Rectangle}}" Path="(local:PointerTracker.Position)" />
+                                                    </MultiBinding>
+                                                </RadialGradientBrush.GradientOrigin>
+                                                <GradientStop Color="Transparent" Offset="0"/>
+                                                <GradientStop x:Name="offset" Color="#88FFFFFF" Offset="0.5"/>
+                                                <GradientStop Color="Transparent" Offset="1"/>
+                                            </RadialGradientBrush>
+                                        </Rectangle.Fill>
+                                    </Rectangle>
+                                </Grid>
+                            </Border>
+
+                            <!-- Content -->
+                            <Border BorderBrush="{x:Null}"
+                                    Margin="{TemplateBinding BorderThickness}"
+                                    Padding="{TemplateBinding Padding}"
+                                    CornerRadius="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Button}, Path=(local:RevealElement.BorderRadius)}">
+                                <ContentPresenter x:Name="ContentPresenter"
+                                                  Content="{TemplateBinding Content}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  TextBlock.Foreground="{TemplateBinding Foreground}"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Focusable="False" />
+                            </Border>
+                        </Grid>
                     </Border>
+
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="background" Property="Background"
+                                    Value="{DynamicResource SystemListLowColorBrush}"/>
+                            <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground"
+                                    Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.MouseOverForeground)}"/>
+                            <Setter TargetName="borderMouseOver" Property="Opacity"
+                                    Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ComboBox}, Path=(local:RevealElement.MouseOverBorderOpacity)}"/>
+                            <Setter TargetName="mouseoverLight" Property="Visibility" Value="Visible"/>
+                            <Setter TargetName="border" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -208,7 +208,7 @@
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Border BorderThickness="2" BorderBrush="Black" />
+                    <Border BorderThickness="2" BorderBrush="{DynamicResource SystemBaseHighColorBrush" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/FluentWPF/Styles/ComboBox.xaml
+++ b/FluentWPF/Styles/ComboBox.xaml
@@ -1,0 +1,351 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:Class="SourceChord.FluentWPF.ComboBoxResourceDictionary"
+                    xmlns:local="clr-namespace:SourceChord.FluentWPF" >
+
+    <local:ComboBoxItemVisualStateManager x:Key="ComboBoxItemVisualStateManager" />
+
+    <!--0.4 is for light theme-->
+    <!--<SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.4" />-->
+    <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.6" />
+    <!--0.6 is for light theme-->
+    <!--<SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.6" />-->
+    <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.8" />
+    <!--0.7 is for light theme-->
+    <!--<SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.7" />-->
+    <SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{Binding Path=(local:AccentColors.ImmersiveSystemAccent)}" Opacity="0.9" />
+
+    <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
+    <Thickness x:Key="FocusThickness">2</Thickness>
+
+    <ControlTemplate x:Key="ComboBoxToggleButton" TargetType="{x:Type ToggleButton}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="32" />
+            </Grid.ColumnDefinitions>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="MouseOver">
+                        <Storyboard>
+                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush.Color">
+                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumColor}" />
+                            </ColorAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="Pressed">
+                        <Storyboard>
+                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListMediumColorBrush}" />
+                            </ObjectAnimationUsingKeyFrames>
+                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush.Color">
+                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColor}" />
+                            </ColorAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="Disabled">
+                        <Storyboard>
+                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseLowColorBrush}" />
+                            </ObjectAnimationUsingKeyFrames>
+                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush.Color">
+                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColor}" />
+                            </ColorAnimationUsingKeyFrames>
+                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph" Storyboard.TargetProperty="Foreground.Color">
+                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColor}" />
+                            </ColorAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="CheckStates">
+                    <VisualState x:Name="Checked">
+                        <Storyboard>
+                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListMediumColorBrush}" />
+                            </ObjectAnimationUsingKeyFrames>
+                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="BorderBrush.Color">
+                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColor}" />
+                            </ColorAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="Unchecked" />
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="FocusStates">
+                    <VisualState x:Name="Focused">
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetName="HighlightBackground" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="HighlightBackground" Storyboard.TargetProperty="BorderBrush.Color">
+                                <DiscreteColorKeyFrame KeyTime="0" Value="Transparent" />
+                            </ColorAnimationUsingKeyFrames>
+                            <ColorAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph" Storyboard.TargetProperty="Foreground.Color">
+                                <DiscreteColorKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumHighColor}" />
+                            </ColorAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="Unfocused" />
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Border x:Name="Background"
+                    Grid.Row="1"
+                    Grid.ColumnSpan="2"
+                    Background="{DynamicResource SystemAltMediumColorBrush}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"/>
+            <Border x:Name="HighlightBackground"
+                    Grid.Row="1"
+                    Grid.ColumnSpan="2"
+                    Background="{DynamicResource SystemListMediumColorBrush}"
+                    BorderBrush="{DynamicResource SystemBaseMediumLowColorBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    Opacity="0" />
+            <TextBlock x:Name="DropDownGlyph"
+                       Grid.Column="1"
+                       IsHitTestVisible="False"
+                       Margin="0,10,10,10"
+                       Foreground="{DynamicResource SystemBaseMediumHighColorBrush}"
+                       FontFamily="Segoe MDL2 Assets"
+                       FontSize="12"
+                       Text="&#xE0E5;"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Center" />
+        </Grid>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ComboBoxTextBox" TargetType="{x:Type TextBox}">
+        <Border x:Name="PART_ContentHost"
+                Focusable="False"
+                Background="{TemplateBinding Background}" />
+    </ControlTemplate>
+
+    <Style x:Key="FluentComboBox" TargetType="{x:Type ComboBox}">
+        <Setter Property="Padding" Value="12,5,0,7" />
+        <Setter Property="MinWidth" Value="64" />
+        <Setter Property="Foreground" Value="{DynamicResource SystemBaseHighColorBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SystemAltMediumLowColorBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource SystemBaseMediumLowColorBrush}" />
+        <Setter Property="BorderThickness" Value="{StaticResource ComboBoxBorderThemeThickness}" />
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="Once" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="FontFamily" Value="{StaticResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontSize" Value="{StaticResource ControlContentThemeFontSize}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ComboBox}">
+                    <Grid x:Name="LayoutRoot">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="EditStates">
+                                <VisualState x:Name="Editable">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="PART_EditableTextBox">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="ContentSite">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Hidden}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Uneditable" />
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <ToggleButton x:Name="ToggleButton"                        
+                                      Template="{StaticResource ComboBoxToggleButton}"
+                                      Grid.Column="2"
+                                      Focusable="True"
+                                      ClickMode="Release"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"/>
+                        <TextBox x:Name="PART_EditableTextBox"
+                                 Style="{StaticResource TextBoxRevealStyle}"
+                                 BorderThickness="0"
+                                 Width="{TemplateBinding Width}"
+                                 Margin="0 0 32 0"
+                                 HorizontalAlignment="Left"
+                                 VerticalAlignment="Center"
+                                 Focusable="True"
+                                 Visibility="Hidden"
+                                 IsReadOnly="{TemplateBinding IsReadOnly}" />
+                        <ContentPresenter x:Name="ContentSite"
+                                          IsHitTestVisible="False"
+                                          Content="{TemplateBinding SelectionBoxItem}"
+                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                          TextBlock.Foreground="{DynamicResource SystemBaseHighColorBrush}"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        <Popup x:Name="Popup"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               Focusable="False"
+                               PopupAnimation="Slide">
+                            <Border x:Name="PopupBorder"
+                                Background="{DynamicResource SystemChromeMediumLowColorBrush}"
+                                BorderBrush="{DynamicResource SystemChromeHighColorBrush}"
+                                BorderThickness="1"
+                                Margin="0,-1,0,-1"
+                                HorizontalAlignment="Stretch">
+                                <ScrollViewer x:Name="ScrollViewer"
+                                              Foreground="{DynamicResource SystemBaseHighColorBrush}"
+                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                              IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                                              MinWidth="{TemplateBinding Width}">
+                                    <StackPanel IsItemsHost="True"
+                                                KeyboardNavigation.DirectionalNavigation="Contained" 
+                                                Margin="0,7,0,7" />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ComboBoxItemFocusVisualStyle">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border BorderThickness="2" BorderBrush="{DynamicResource SystemBaseHighColorBrush}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="{x:Type ComboBoxItem}" TargetType="{x:Type ComboBoxItem}">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Foreground" Value="{DynamicResource SystemBaseHighColorBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="Local" />
+        <Setter Property="Padding" Value="11,5,11,7" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="KeyboardNavigation.ControlTabNavigation" Value="None" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource ComboBoxItemFocusVisualStyle}" />
+        <EventSetter Event="PreviewMouseLeftButtonDown" Handler="ComboBoxItem_PreviewMouseLeftButtonDown" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ComboBoxItem}">
+                    <Border x:Name="LayoutRoot"
+                            MouseEnter="LayoutRoot_MouseEnter"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <VisualStateManager.CustomVisualStateManager>
+                            <local:ComboBoxItemVisualStateManager />
+                        </VisualStateManager.CustomVisualStateManager>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="FluentCommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="PointerOver">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListLowColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemListMediumColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderThickness">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource FocusThickness}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Selected">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="SelectedDisabled">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseMediumLowColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="SelectedPointerOver">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemControlHighlightListAccentMediumBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="SelectedPressed">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemControlHighlightListAccentHighBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource TransparentBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="(TextBlock.Foreground)">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{DynamicResource SystemBaseHighColorBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          TextBlock.Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Margin="{TemplateBinding Padding}"
+                                          Focusable="False" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/FluentWPF/Styles/ComboBox.xaml.cs
+++ b/FluentWPF/Styles/ComboBox.xaml.cs
@@ -1,0 +1,96 @@
+﻿using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace SourceChord.FluentWPF
+{
+    public class ComboBoxItemVisualStateManager : VisualStateManager
+    {
+        private const string Normal = "Normal";
+        internal const string PointerOver = "PointerOver";
+        internal const string KeyboardFocus = "KeyboardFocus";
+        private const string Disabled = "Disabled";
+        internal const string Pressed = "Pressed";
+        private const string Selected = "Selected";
+        private const string SelectedDisabled = "SelectedDisabled";
+        private const string SelectedPointerOver = "SelectedPointerOver";
+        private const string SelectedPressed = "SelectedPressed";
+
+        protected override bool GoToStateCore(FrameworkElement control, FrameworkElement stateGroupsRoot, string stateName, VisualStateGroup group, VisualState state, bool useTransitions)
+        {
+            if (group is null || state is null)
+            {
+                return false;
+            }
+
+            var item = (ComboBoxItem)control;
+
+            // If no state is defined yet, go to Normal without additional checks
+            if (group.CurrentState == null)
+            {
+                var normal = group.States.OfType<VisualState>().Single(s => s.Name == Normal);
+                return base.GoToStateCore(item, stateGroupsRoot, Normal, group, normal, false);
+            }
+
+            var status = new
+            {
+                Disabled = !item.IsEnabled,
+                //KeyboardFocus = item.IsKeyboardFocusWithin,
+                PointerOver = item.IsMouseOver || item.IsStylusOver,
+                Pressed = stateName == Pressed,
+                Selected = item.IsSelected
+            };
+
+            var nextStateName = status switch
+            {
+                { Disabled: true, Selected: true } => SelectedDisabled,
+                { Disabled: true } => Disabled,
+                { Pressed: true, Selected: true } => SelectedPressed,
+                { Pressed: true } => Pressed,
+                { PointerOver: true, Selected: true } => SelectedPointerOver,
+                { PointerOver: true } => PointerOver,
+                //{ KeyboardFocus: true } => KeyboardFocus,
+                { Selected: true } => Selected,
+                _ => Normal
+            };
+
+            // Avoid transition from state to itself (which would produce a false result either way)
+            if (group.CurrentState.Name == nextStateName)
+            {
+                return false;
+            }
+
+            var nextState = group.States.OfType<VisualState>().Single(s => s.Name == nextStateName);
+            return base.GoToStateCore(item, stateGroupsRoot, nextStateName, group, nextState, false);
+        }
+    }
+
+    public partial class ComboBoxResourceDictionary : ResourceDictionary
+    {
+        private void ComboBoxItem_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            // Prevent Pressed visual state with touch devices
+            if (e.StylusDevice != null)
+            {
+                VisualStateManager.GoToState((ComboBoxItem)sender, ComboBoxItemVisualStateManager.Pressed, false);
+            }
+        }
+
+        /// <summary>
+        /// Handles the MouseEnter event on a <see cref="ComboBoxItem"/>.
+        /// It is required since the hovering is not always handled properly with the modified visual state.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void LayoutRoot_MouseEnter(object sender, MouseEventArgs e)
+        {
+            // Prevent PointerOver visual state with touch devices
+            if (e.StylusDevice == null)
+            {
+                var item = ((FrameworkElement)sender).TemplatedParent;
+                VisualStateManager.GoToState((ComboBoxItem)item, ComboBoxItemVisualStateManager.PointerOver, false);
+            }
+        }
+    }
+}

--- a/FluentWPF/Styles/ComboBox.xaml.cs
+++ b/FluentWPF/Styles/ComboBox.xaml.cs
@@ -71,7 +71,7 @@ namespace SourceChord.FluentWPF
         private void ComboBoxItem_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             // Prevent Pressed visual state with touch devices
-            if (e.StylusDevice != null)
+            if (e.StylusDevice == null)
             {
                 VisualStateManager.GoToState((ComboBoxItem)sender, ComboBoxItemVisualStateManager.Pressed, false);
             }

--- a/FluentWPF/Styles/Controls.xaml
+++ b/FluentWPF/Styles/Controls.xaml
@@ -8,6 +8,7 @@
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/ScrollBar.xaml" />
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/TextBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/TextBlock.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/ComboBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/Window.xaml" />
         <ResourceDictionary Source="pack://application:,,,/FluentWPF;component/Styles/Menu.xaml" />
     </ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
With this PR I replicated the fluent design style for Combobox.

The style works properly with mouse and multitouch devices.
I haven't tried it with a stylus (nor RTL cultures).

Known issues:
- Keyboard focus produces coloured border but I wasn't able to set the background properly

TODOs:
- FluentWPF/Styles/ComboBox.xaml
  - on line 151there is a reference to `ContentControlThemeFontFamily`. I am not sure if you already implemented it. In case you didn't, [here](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.fontfamily.xamlautofontfamily) a reference to proper values

Finally, the `ComboboxItem` style should have an additional `Reveal` style (to apply on `SelectedPressed` visual state). That is beyond my skills.


One final word: I added support for C#8 for the project. Since it already targets .NET Core 3, it has no contraindications with older frameworks.
