### PR TITLE
switch back to ACCENT_ENABLE_ACRYLICBLURBEHIND on latest insider releases to avoid perf issues

### DIFF
--- a/FluentWPF/Utility/AcrylicHelper.cs
+++ b/FluentWPF/Utility/AcrylicHelper.cs
@@ -59,7 +59,11 @@ namespace SourceChord.FluentWPF.Utility
             // ウィンドウ背景のぼかしを行うのはWindows10の場合のみ
             // OSのバージョンに従い、AccentStateを切り替える
             var currentVersion = SystemInfo.Version.Value;
-            if (currentVersion >= VersionInfos.Windows10_1903)
+            if (currentVersion >= VersionInfos.Windows10_Insider_21327)
+            {
+                accent.AccentState = AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND;
+            }
+            else if (currentVersion >= VersionInfos.Windows10_1903)
             {
                 // Windows10 1903以降では、ACCENT_ENABLE_ACRYLICBLURBEHINDを用いると、ウィンドウのドラッグ移動などでマウス操作に追従しなくなる。
                 // SetWindowCompositionAttribute関数の動作が修正されるまで、ACCENT_ENABLE_ACRYLICBLURBEHINDは使用しない。

--- a/FluentWPF/Utility/VersionInfos.cs
+++ b/FluentWPF/Utility/VersionInfos.cs
@@ -22,5 +22,6 @@ namespace SourceChord.FluentWPF.Utility
         public static VersionInfo Windows10_1803 { get { return new VersionInfo(10, 0, 17134); } }
         public static VersionInfo Windows10_1809 { get { return new VersionInfo(10, 0, 17763); } }
         public static VersionInfo Windows10_1903 { get { return new VersionInfo(10, 0, 18362); } }
+        public static VersionInfo Windows10_Insider_21327 { get { return new VersionInfo(10, 0, 21327); } }
     }
 }


### PR DESCRIPTION
Looks like not only does BLURBEHIND now cause perf issues, but ACRYLICBLURBEHIND doesnt anymore. This seems like the more correct blur to use and using it on the latest releases avoids having to disable acrylic because of lag/perf issues