### PR TITLE
Update AcrylicWindow's acrylic effects

### DIFF
--- a/FluentWPF/AcrylicContextMenu.cs
+++ b/FluentWPF/AcrylicContextMenu.cs
@@ -59,7 +59,7 @@ namespace SourceChord.FluentWPF
             base.OnOpened(e);
 
             var hwnd = (HwndSource)HwndSource.FromVisual(this);
-            AcrylicHelper.EnableBlur(hwnd.Handle, AccentFlagsType.Popup);
+            AcrylicHelper.SetBlur(hwnd.Handle, AccentFlagsType.Popup);
         }
     }
 }

--- a/FluentWPF/AcrylicPopup.cs
+++ b/FluentWPF/AcrylicPopup.cs
@@ -60,7 +60,7 @@ namespace SourceChord.FluentWPF
             base.OnOpened(e);
 
             var hwnd = (HwndSource)HwndSource.FromVisual(this.Child);
-            AcrylicHelper.EnableBlur(hwnd.Handle, AccentFlagsType.Popup);
+            AcrylicHelper.SetBlur(hwnd.Handle, AccentFlagsType.Popup);
         }
     }
 }

--- a/FluentWPF/AcrylicToolTip.cs
+++ b/FluentWPF/AcrylicToolTip.cs
@@ -57,7 +57,7 @@ namespace SourceChord.FluentWPF
         {
             base.OnOpened(e);
             var hwnd = (HwndSource)HwndSource.FromVisual(this);
-            AcrylicHelper.EnableBlur(hwnd.Handle, AccentFlagsType.Popup);
+            AcrylicHelper.SetBlur(hwnd.Handle, AccentFlagsType.Popup);
         }
     }
 }

--- a/FluentWPF/RevealPanel.cs
+++ b/FluentWPF/RevealPanel.cs
@@ -48,7 +48,7 @@ namespace SourceChord.FluentWPF
     [TemplateVisualState(Name = "MouseOver", GroupName = "CommonStates")]
     [TemplateVisualState(Name = "Pressed", GroupName = "CommonStates")]
     [TemplateVisualState(Name = "Disabled", GroupName = "CommonStates")]
-    public class RevealPanel : ContentControl//Control
+    public class RevealPanel : ContentControl
     {
         public bool IsPressed
         {

--- a/FluentWPF/Styles/Window.xaml
+++ b/FluentWPF/Styles/Window.xaml
@@ -325,6 +325,7 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="{Binding Path=(local:AccentColors.ImmersiveSystemAccentBrush)}" />
         <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="WindowStyle" Value="None" />
         <Setter Property="ContentTemplate">
             <Setter.Value>
                 <DataTemplate>
@@ -388,7 +389,14 @@
             <Trigger Property="local:AcrylicWindow.AcrylicWindowStyle" Value="None">
             </Trigger>
             <Trigger Property="WindowState" Value="Maximized">
-                <Setter Property="BorderThickness" Value="8" />
+                <Setter Property="WindowChrome.WindowChrome">
+                    <Setter.Value>
+                        <WindowChrome CaptionHeight="{x:Static SystemParameters.CaptionHeight}"
+                                      GlassFrameThickness="1"
+                                      ResizeBorderThickness="0" UseAeroCaptionButtons="False" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="BorderThickness" Value="0"/>
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/FluentWPF/Utility/AcrylicHelper.cs
+++ b/FluentWPF/Utility/AcrylicHelper.cs
@@ -52,31 +52,11 @@ namespace SourceChord.FluentWPF.Utility
         [DllImport("user32.dll")]
         internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
 
-        internal static void EnableBlur(IntPtr hwnd, AccentFlagsType style = AccentFlagsType.Window)
+        internal static void SetBlur(IntPtr hwnd, AccentFlagsType style = AccentFlagsType.Window, AccentState? state = null)
         {
             var accent = new AccentPolicy();
             var accentStructSize = Marshal.SizeOf(accent);
-            // ウィンドウ背景のぼかしを行うのはWindows10の場合のみ
-            // OSのバージョンに従い、AccentStateを切り替える
-            var currentVersion = SystemInfo.Version.Value;
-            if (currentVersion >= VersionInfos.Windows10_1903)
-            {
-                // Windows10 1903以降では、ACCENT_ENABLE_ACRYLICBLURBEHINDを用いると、ウィンドウのドラッグ移動などでマウス操作に追従しなくなる。
-                // SetWindowCompositionAttribute関数の動作が修正されるまで、ACCENT_ENABLE_ACRYLICBLURBEHINDは使用しない。
-                accent.AccentState = AccentState.ACCENT_ENABLE_BLURBEHIND;
-            }
-            else if (currentVersion >= VersionInfos.Windows10_1809)
-            {
-                accent.AccentState = AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND;
-            }
-            else if (currentVersion >= VersionInfos.Windows10)
-            {
-                accent.AccentState = AccentState.ACCENT_ENABLE_BLURBEHIND;
-            }
-            else
-            {
-                accent.AccentState = AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT;
-            }
+            accent.AccentState = state ?? SelectAccentState();
 
             if (style == AccentFlagsType.Window)
             {
@@ -101,6 +81,34 @@ namespace SourceChord.FluentWPF.Utility
             SetWindowCompositionAttribute(hwnd, ref data);
 
             Marshal.FreeHGlobal(accentPtr);
+        }
+
+        internal static AccentState SelectAccentState()
+        {
+            AccentState state;
+            // ウィンドウ背景のぼかしを行うのはWindows10の場合のみ
+            // OSのバージョンに従い、AccentStateを切り替える
+            var currentVersion = SystemInfo.Version.Value;
+            if (currentVersion >= VersionInfos.Windows10_1903)
+            {
+                // Windows10 1903以降では、ACCENT_ENABLE_ACRYLICBLURBEHINDを用いると、ウィンドウのドラッグ移動などでマウス操作に追従しなくなる。
+                // SetWindowCompositionAttribute関数の動作が修正されるまで、ACCENT_ENABLE_ACRYLICBLURBEHINDは使用しない。
+                state = AccentState.ACCENT_ENABLE_BLURBEHIND;
+            }
+            else if (currentVersion >= VersionInfos.Windows10_1809)
+            {
+                state = AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND;
+            }
+            else if (currentVersion >= VersionInfos.Windows10)
+            {
+                state = AccentState.ACCENT_ENABLE_BLURBEHIND;
+            }
+            else
+            {
+                state = AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT;
+            }
+
+            return state;
         }
     }
 }

--- a/FluentWPF/Utility/AcrylicHelper.cs
+++ b/FluentWPF/Utility/AcrylicHelper.cs
@@ -83,32 +83,31 @@ namespace SourceChord.FluentWPF.Utility
             Marshal.FreeHGlobal(accentPtr);
         }
 
-        internal static AccentState SelectAccentState()
+        internal static AccentState SelectAccentState(AcrylicAccentState state = AcrylicAccentState.Default)
         {
-            AccentState state;
-            // ウィンドウ背景のぼかしを行うのはWindows10の場合のみ
-            // OSのバージョンに従い、AccentStateを切り替える
-            var currentVersion = SystemInfo.Version.Value;
-            if (currentVersion >= VersionInfos.Windows10_1903)
+            // ウィンドウのアクリル効果を設定する
+            AccentState value = state switch
             {
-                // Windows10 1903以降では、ACCENT_ENABLE_ACRYLICBLURBEHINDを用いると、ウィンドウのドラッグ移動などでマウス操作に追従しなくなる。
-                // SetWindowCompositionAttribute関数の動作が修正されるまで、ACCENT_ENABLE_ACRYLICBLURBEHINDは使用しない。
-                state = AccentState.ACCENT_ENABLE_BLURBEHIND;
-            }
-            else if (currentVersion >= VersionInfos.Windows10_1809)
-            {
-                state = AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND;
-            }
-            else if (currentVersion >= VersionInfos.Windows10)
-            {
-                state = AccentState.ACCENT_ENABLE_BLURBEHIND;
-            }
-            else
-            {
-                state = AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT;
-            }
+                // ウィンドウ背景のぼかしを行うのはWindows10の場合のみ
+                // OSのバージョンに従い、AccentStateを切り替える
+                AcrylicAccentState.Default => SystemInfo.Version.Value switch
+                {
+                    // Windows10 1903以降では、ACCENT_ENABLE_ACRYLICBLURBEHINDを用いると、ウィンドウのドラッグ移動などでマウス操作に追従しなくなる。
+                    // ウィンドウの移動/リサイズ中だけ、ACCENT_ENABLE_ACRYLICBLURBEHINDを無効にして、この問題を回避する
+                    //var version when version >= VersionInfos.Windows10_1903 => AccentState.ACCENT_ENABLE_BLURBEHIND,
+                    var version when version >= VersionInfos.Windows10_1809 => AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND,
+                    var version when version >= VersionInfos.Windows10 => AccentState.ACCENT_ENABLE_BLURBEHIND,
+                    _ => AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT,
+                },
+                AcrylicAccentState.Disabled => AccentState.ACCENT_DISABLED,
+                AcrylicAccentState.Gradient => AccentState.ACCENT_ENABLE_GRADIENT,
+                AcrylicAccentState.TransparentGradient => AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT,
+                AcrylicAccentState.BlurBehind => AccentState.ACCENT_ENABLE_BLURBEHIND,
+                AcrylicAccentState.AcrylicBlurBehind => AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND,
+                _ => throw new InvalidOperationException(),
+            };
 
-            return state;
+            return value;
         }
     }
 }

--- a/Sample/FluentWPFSample/Views/AcrylicWindow3.xaml
+++ b/Sample/FluentWPFSample/Views/AcrylicWindow3.xaml
@@ -10,6 +10,7 @@
                   Title="AcrylicWindow3" Height="450" Width="800"
                   ResizeMode="CanResizeWithGrip"
                   fw:AcrylicWindow.AcrylicWindowStyle="{Binding SelectedValue, ElementName=cmbStyle}"
+                  fw:AcrylicWindow.AcrylicAccentState="{Binding SelectedValue, ElementName=cmbState}"
                   Icon="/Assets/Images/logo_icon.png">
     <Window.Style>
         <Style TargetType="{x:Type Window}">
@@ -46,12 +47,23 @@
                 <x:Type TypeName="fw:AcrylicWindowStyle"/>
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
+        <ObjectDataProvider x:Key="states" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="fw:AcrylicAccentState"/>
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
     </Window.Resources>
     <Grid>
-        <TextBlock HorizontalAlignment="Left" Margin="10,10,0,0" TextWrapping="Wrap" Text="AcrylicWindowStyle" VerticalAlignment="Top"/>
-        <ComboBox x:Name="cmbStyle" HorizontalAlignment="Left" Margin="10,31,0,0" VerticalAlignment="Top" Width="120"
+        <TextBlock HorizontalAlignment="Left" Margin="10,32,0,0" TextWrapping="Wrap" Text="AcrylicAccentState" VerticalAlignment="Top"/>
+        <ComboBox x:Name="cmbState" HorizontalAlignment="Left" Margin="10,53,0,0" VerticalAlignment="Top" Width="120"
+                  ItemsSource="{Binding Source={StaticResource states}}"
+                  SelectedIndex="5"/>
+
+        <TextBlock HorizontalAlignment="Left" Margin="10,111,0,0" TextWrapping="Wrap" Text="AcrylicWindowStyle" VerticalAlignment="Top"/>
+        <ComboBox x:Name="cmbStyle" HorizontalAlignment="Left" Margin="10,132,0,0" VerticalAlignment="Top" Width="120"
                   ItemsSource="{Binding Source={StaticResource styles}}"
                   SelectedIndex="0"/>
-        <CheckBox x:Name="chkCustomTitleBar" Content="Custom TitleBar" HorizontalAlignment="Left" Margin="10,80,0,0" VerticalAlignment="Top"/>
+        <CheckBox x:Name="chkCustomTitleBar" Content="Custom TitleBar" HorizontalAlignment="Left" Margin="10,169,0,0" VerticalAlignment="Top"/>
+
     </Grid>
 </fw:AcrylicWindow>

--- a/Sample/FluentWPFSample/Views/MusicPlayer.xaml
+++ b/Sample/FluentWPFSample/Views/MusicPlayer.xaml
@@ -6,8 +6,7 @@
                   xmlns:local="clr-namespace:FluentWPFSample.Views"
                   xmlns:fw="clr-namespace:SourceChord.FluentWPF;assembly=FluentWPF"
                   mc:Ignorable="d"
-                  Title="MusicPlayer" Height="300" Width="300"
-                  fw:AcrylicWindow.Enabled="True">
+                  Title="MusicPlayer" Height="300" Width="300">
     <Grid fw:PointerTracker.Enabled="True" Background="#01FFFFFF">
         <Grid Height="70" VerticalAlignment="Bottom" HorizontalAlignment="Center">
             <Grid.Resources>
@@ -18,8 +17,6 @@
                     <Setter Property="Background" Value="Transparent" />
                     <Setter Property="FontSize" Value="20" />
                     <Setter Property="FontFamily" Value="Segoe MDL2 Assets" />
-                    <!--<Setter Property="VerticalAlignment" Value="Center" />
-                    <Setter Property="VerticalContentAlignment" Value="Center" />-->
                 </Style>
             </Grid.Resources>
             <Grid.ColumnDefinitions>


### PR DESCRIPTION
* Add AcrylicWindow.AcrylicAccentState property
  * Specifies the type of acrylic effects.
* Support Disabling acrylic effect by setting AcrylicWindow.Enabled to false(#88, #94)
* Support ACCENT_ENABLE_ACRYLICBLURBEHIND(#42)
  * Windows10 still has laggy behavior with ACRYLICBLURBEHIND
  * Avoid laggy behavior by disabling acrylic blur when resizing or moving the window.
* Fix full screen behavior(#36)
  * Prevent showing unnecessary blurred region on the another display
