### PR TITLE
Make Disabled Button foreground consistent with OS

### DIFF
--- a/FluentWPF/Styles/Button.xaml
+++ b/FluentWPF/Styles/Button.xaml
@@ -148,7 +148,7 @@
                                         <animation:BrushAnimation Storyboard.TargetProperty="(TextElement.Foreground)" Storyboard.TargetName="contentPresenter"
                                                                   Duration="0:0:0.100" AutoReverse="False">
                                             <animation:BrushAnimation.To>
-                                                <SolidColorBrush Color="#FF838383"/>
+                                                <SolidColorBrush Color="#66FFFFFF"/>
                                             </animation:BrushAnimation.To>
                                             <animation:BrushAnimation.EasingFunction>
                                                 <SineEase EasingMode="EaseInOut"/>


### PR DESCRIPTION
Current foreground color makes text hard to read when using accent color as window background.

Windows 10 Action Center:
![ActionCenter](https://user-images.githubusercontent.com/51774833/137587247-3044c2bc-ad4d-4335-8f64-af02d5e2be6f.png)

Before:
![Before](https://user-images.githubusercontent.com/51774833/137587296-0add4630-6979-4fd9-a4bb-73c9e6ae9542.png)

After:
![After](https://user-images.githubusercontent.com/51774833/137588399-f6bf139a-0f78-4b0e-bf1c-bd044e24c4f9.png)

After (light):
![AfterLight](https://user-images.githubusercontent.com/51774833/137588404-edaf4915-e720-48fe-87b0-187e06218d13.png)

After (dark):
![AfterDark](https://user-images.githubusercontent.com/51774833/137588407-59d434fd-b837-4b23-89ce-e04c0978a7de.png)


