### PR TITLE
Fix get icon

### DIFF
--- a/FluentWPF/Utility/IconHelper.cs
+++ b/FluentWPF/Utility/IconHelper.cs
@@ -19,8 +19,10 @@ namespace SourceChord.FluentWPF.Utility
             {
                 if (appIcon == null)
                 {
-                    var path = System.Reflection.Assembly.GetEntryAssembly().Location;
-                    appIcon = GetIcon(path);
+                    var assembly = System.Reflection.Assembly.GetEntryAssembly();
+                    assembly ??= System.Reflection.Assembly.GetCallingAssembly();
+
+                    appIcon = GetIcon(assembly.Location);
                 }
                 return appIcon;
             }

--- a/FluentWPF/Utility/IconHelper.cs
+++ b/FluentWPF/Utility/IconHelper.cs
@@ -16,7 +16,7 @@ namespace SourceChord.FluentWPF.Utility
                 if (appIcon == null)
                 {
                     var assembly = System.Reflection.Assembly.GetEntryAssembly();
-                    assembly ??= System.Reflection.Assembly.GetCallingAssembly();
+                    assembly ??= System.Reflection.Assembly.GetExecutingAssembly();
 
                     appIcon = GetIcon(assembly.Location);
                 }

--- a/FluentWPF/Utility/IconHelper.cs
+++ b/FluentWPF/Utility/IconHelper.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;


### PR DESCRIPTION
## Description
In larger applications with multiple assemblies, entry assembly may be null.
This will cause issues when trying to display an `AcrylicWindow` for example, which uses the `AppIcon`.
(Even when `AcrylicWindowStyle` is set to `NoIcon` / `None`)

The reason I used `Assembly#GetExecutingAssembly` over Assembly`#GetCallingAssembly` can be [found here](https://stackoverflow.com/questions/12669515/are-getcallingassembly-and-getexecutingassembly-equally-prone-to-jit-inlinin).  
It does not matter in my case but it may in someone elses.

The fix is also written in a way that will not affect other programs, only if the EntryAssembly returns null, it will get the ExecutingAssembly.

## Related Issue
Resolves #87

## Extra
I also removed the using statements that were not in use.