### PR TITLE
Fix crash on windows 7

### DIFF
--- a/FluentWPF/AcrylicWindow.cs
+++ b/FluentWPF/AcrylicWindow.cs
@@ -372,18 +372,20 @@ namespace SourceChord.FluentWPF
                 var monitorRectangle = monitorInfo.rcMonitor;
 
                 var win = (Window)HwndSource.FromHwnd(hwnd).RootVisual;
+                uint dpiX, dpiY;
                 if (Environment.OSVersion.Version.Major >= 10 || (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor == 3))
                 {
-                    GetDpiForMonitor(hMonitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var dpiX, out var dpiY);
+                    GetDpiForMonitor(hMonitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out dpiX, out dpiY);
                 }
                 else
                 {
                     // must be an old version of Windows (7 or 8)
                     // an old version of Windows (7 or 8)
                     // Get scale of main window and assume scale is the same for all monitors
-                    var dpiScale = VisualTreeHelper.GetDpi(Application.Current.MainWindow);
-                    dpiX = dpiScale.DpiScaleX;
-                    dpiY = dpiScale.DpiScaleY;
+                    var dpiXProperty = typeof(SystemParameters).GetProperty("DpiX", BindingFlags.NonPublic | BindingFlags.Static);
+                    var dpiYProperty = typeof(SystemParameters).GetProperty("Dpi", BindingFlags.NonPublic | BindingFlags.Static);
+                    dpiX = (uint)dpiXProperty.GetValue(null, null);
+                    dpiY = (uint)dpiYProperty.GetValue(null, null);
                 }
                 var maxWidth = win.MaxWidth / 96.0 * dpiX;
                 var maxHeight = win.MaxHeight / 96.0 * dpiY;

--- a/FluentWPF/AcrylicWindow.cs
+++ b/FluentWPF/AcrylicWindow.cs
@@ -372,7 +372,19 @@ namespace SourceChord.FluentWPF
                 var monitorRectangle = monitorInfo.rcMonitor;
 
                 var win = (Window)HwndSource.FromHwnd(hwnd).RootVisual;
-                GetDpiForMonitor(hMonitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var dpiX, out var dpiY);
+                if (Environment.OSVersion.Version.Major >= 10 || (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor == 3))
+                {
+                    GetDpiForMonitor(hMonitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var dpiX, out var dpiY);
+                }
+                else
+                {
+                    // must be an old version of Windows (7 or 8)
+                    // an old version of Windows (7 or 8)
+                    // Get scale of main window and assume scale is the same for all monitors
+                    var dpiScale = VisualTreeHelper.GetDpi(Application.Current.MainWindow);
+                    dpiX = dpiScale.DpiScaleX;
+                    dpiY = dpiScale.DpiScaleY;
+                }
                 var maxWidth = win.MaxWidth / 96.0 * dpiX;
                 var maxHeight = win.MaxHeight / 96.0 * dpiY;
                 var minWidth = win.MinWidth / 96.0 * dpiX;


### PR DESCRIPTION
shcore.dll not exist on windows 7, see this issue : https://github.com/sourcechord/FluentWPF/issues/157